### PR TITLE
feat: add standard relays json

### DIFF
--- a/noports/standard_relays.json
+++ b/noports/standard_relays.json
@@ -1,0 +1,1 @@
+{"standard_relays":{"@rv_am":{},"@rv_eu":{},"@rv_ap":{},"@rv_oc":{}}}

--- a/noports/standard_relays.json
+++ b/noports/standard_relays.json
@@ -1,1 +1,1 @@
-{"standard_relays":{"@rv_am":{},"@rv_eu":{},"@rv_ap":{},"@rv_oc":{}}}
+{"standard_relays":{"@rv_am":[],"@rv_eu":[],"@rv_ap":[],"@rv_oc":[]}}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- add a list of standard relays that can be fetched by noports when needed

**- How I did it**
- added file `noports/standard_relays.json` that contains a JSON of the standard relays.
- This is needed here so that whenever new relays are added, noports can automatically fetch them. Instead of hardcoding the relays into the code, which allows zero flexibility.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
feat: add standard relays json