### PR TITLE
fix: standard relays maps to an object instead of list

### DIFF
--- a/noports/standard_relays.json
+++ b/noports/standard_relays.json
@@ -1,1 +1,1 @@
-{"standard_relays":{"@rv_am":[],"@rv_eu":[],"@rv_ap":[],"@rv_oc":[]}}
+{"standard_relays":{"@rv_am":{},"@rv_eu":{},"@rv_ap":{},"@rv_oc":{}}}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- change format of standard relays from { 'rv' : [ ] } to { 'rv' : { } }

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fix: standard relays maps to an object instead of list